### PR TITLE
Arrumando configuração do module alias

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
-    "strict": true
-  }
+    "strict": true,
+    "baseUrl": "./",
+    "paths": {
+      "@screens/*": ["screens/*"],
+    }
+  },
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Ajusta a configuração do module alias no tsconfig.json para garantir que os caminhos sejam reconhecidos corretamente pelo TypeScript e pelo VSCode. 